### PR TITLE
Make some variables overridable and check if we need sd_plugins to be…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,10 @@ sd_groups:
   apache: 'none'
   mysql: 'none'
   proxy: 'none'
+
+
+sd_repo_public_key_uri: 'https://www.serverdensity.com/downloads/boxedice-public.key'
+sd_agent_plugins_dir: '/usr/bin/sd-agent/plugins'
+sd_plugins_files_dir: "{{inventory_dir}}/files/sd-plugins"
+sd_template_config: 'config.cfg'
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: 'ServerDensity | Install Public Repo Key'
   apt_key:
-    url='https://www.serverdensity.com/downloads/boxedice-public.key'
+    url="{{ sd_repo_public_key_uri }}"
     state=present
 
 - name: 'ServerDensity | Add ServerDensity Repository To Apt'
@@ -29,19 +29,20 @@
 
 - name: 'ServerDensity | Create Plugins Directory'
   file:
-    dest='/usr/bin/sd-agent/plugins'
+    dest="{{ sd_agent_plugins_dir }}"
     state=directory
     mode=755
 
 - name: 'ServerDensity | Copy Plugins'
   copy:
-    src={{inventory_dir}}/files/sd-plugins/{{item.1}}
-    dest=/usr/bin/sd-agent/plugins/{{item.1}}
+    src="{{ sd_plugins_files_dir }}/{{item.1}}"
+    dest="{{ sd_agent_plugins_dir }}/{{item.1}}"
   with_items: sd_plugins|dictsort
+  when: sd_plugins|length > 0
   notify: 'ServerDensity | Restart Agent'
 
 - name: 'ServerDensity | Configure The Agent'
-  template: src=config.cfg
+  template: src="{{ sd_template_config }}"
             dest=/etc/sd-agent/config.cfg
             owner=root
             group=root

--- a/templates/config.cfg
+++ b/templates/config.cfg
@@ -6,7 +6,7 @@
 sd_url: {{sd_url}}
 agent_key: {{sd_agent_key}}
 
-plugin_directory: /usr/bin/sd-agent/plugins
+plugin_directory: {{ sd_agent_plugins_dir }}
 logging_level: {{sd_logging_level}}
 
 {% if sd_groups.apache != 'none' and inventory_hostname in groups[sd_groups.apache] %}


### PR DESCRIPTION
… copied

1.Allows user to create their own config file if they so wish
2. In the scenario where a URL changes (i.e. public repo key URI), users can override the variable without discarding the entire role until it is updated. Also initial step towards cross-platform (CentOS etc) role
3. Allow plugins directory to be changed should the user wish.
