### PR TITLE
Change call to serverdenisty plugin so that it does not automatically…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ sd_api_token: ''
 sd_api_cache_file: false
 sd_agent_key: ''
 sd_logging_level: 'info'
+sd_alert_cleanup: true
+sd_force_update: true
 sd_plugins: []
 sd_groups:
   apache: 'none'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,8 +5,8 @@
   local_action:
     serverdensity
     api_token={{sd_api_token}}
-    cleanup=true
-    force=true
+    cleanup={{sd_alert_cleanup}}
+    force={{ sd_force_update }}
     cache={{sd_api_cache_file}}
 
 - name: 'ServerDensity | Install Public Repo Key'


### PR DESCRIPTION
Change call to serverdenisty plugin so that it can be set to not automatically wipe all alerts silently (bad) without telling you. The plugin call assumes that SD is entirely managed via the role, which means that any roles created manually outside of the role will be wiped. This is not an edge case, and while there is an argument that all alerts should be managed via Ansible, there also comes the issue of if you have individual apps/servers as discrete playbooks (i.e. one per customer) and then wipe all the others... A costly mistake on our part in terms of time.
